### PR TITLE
layout: Update the navigation to match the openvswith.org

### DIFF
--- a/ovs_sphinx_theme/theme/ovs/layout.html
+++ b/ovs_sphinx_theme/theme/ovs/layout.html
@@ -52,16 +52,12 @@
           <li>
             <a href="/">Documentation
               <span class="drop-icon">▾</span>
-              <label title="Toggle Drop-down" class="drop-icon" for="sm20">▾</label>
+              <label title="Toggle Drop-down" class="drop-icon" for="sm54">▾</label>
             </a>
-            <input type="checkbox" id="sm20">
+            <input type="checkbox" id="sm54">
             <ul class="sub-menu">
               <li>
                 <a href="/">Open vSwitch (latest)</a>
-              </li>
-              <li>
-                <a href="//www.openvswitch.org/support/dist-docs-2.5">Open vSwitch 2.5.x
-                </a>
               </li>
               <li>
                 <a href="//www.openvswitch.org/support/dist-docs">Man Pages</a>
@@ -71,18 +67,51 @@
           <li>
             <a href="">Talks &amp; Presentations
               <span class="drop-icon">▾</span>
-              <label title="Toggle Drop-down" class="drop-icon" for="sm21">▾</label>
+              <label title="Toggle Drop-down" class="drop-icon" for="sm55">▾</label>
             </a>
-            <input type="checkbox" id="sm21">
+            <input type="checkbox" id="sm55">
             <ul class="sub-menu">
               <li>
-                <a href="//www.openvswitch.org/support/ovscon2016">OVScon 2016</a>
-              </li>
-              <li>
-                <a href="//www.openvswitch.org/support/ovscon2015">OVScon 2015</a>
-              </li>
-              <li>
-                <a href="//www.openvswitch.org/support/ovscon2014">OVScon 2014</a>
+                <a href="">Conferences
+                  <span class="drop-icon">▾</span>
+                  <label title="Toggle Drop-down" class="drop-icon" for="sm56">▾</label>
+                </a>
+                <input type="checkbox" id="sm56">
+                <ul class="sub-menu">
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2023">OVS+OVNcon 2023</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2022">OVS+OVNcon 2022</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2021">OVS+OVNcon 2021</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2020">OVS+OVNcon 2020</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2019">OVS+OVNcon 2019</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2018">OVScon 2018</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2017">OVScon 2017</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/boston2017">OpenStack Boston 2017</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2016">OVScon 2016</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2015">OVScon 2015</a>
+                  </li>
+                  <li>
+                    <a href="//www.openvswitch.org/support/ovscon2014">OVScon 2014</a>
+                  </li>
+                </ul>
               </li>
               <li>
                 <a href="//www.openvswitch.org/support/papers">Papers</a>
@@ -92,6 +121,9 @@
               </li>
               <li>
                 <a href="//www.openvswitch.org/support/interviews">Interviews</a>
+              </li>
+              <li>
+                <a href="//www.youtube.com/OpenvSwitchOrg/">YouTube Channel</a>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
docs.openvswitch.org navigation panel is missing links to recent conferences and that confuses users into thinking that there are no OVS conferences anymore.

@russellb @orgcandman 